### PR TITLE
Update underlying parser to allow “$” escapes.

### DIFF
--- a/etc/package-lock.json
+++ b/etc/package-lock.json
@@ -6,13 +6,13 @@
     "": {
       "name": "vendor",
       "dependencies": {
-        "@netflix/x-element": "2.0.0-rc.1"
+        "@netflix/x-element": "2.0.0-rc.2"
       }
     },
     "node_modules/@netflix/x-element": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.1.tgz",
-      "integrity": "sha512-m2wathtyrF/fnHlR3V4AHPtOzeAKvJ+77mm8HPNbj+7EIoAPmm7E4lpGUU+U1yYp8qdRWIW4PEumI4Q/a3FNeQ==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.2.tgz",
+      "integrity": "sha512-airnUBQBELI+EWd3+81wkfMwTKCse899ZxjzzFP6yEAP1zES6s5U+z2B+sn0RC+wlwYW+Gv1ZhFO7IrKcLTzOw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.11.0",

--- a/etc/package.json
+++ b/etc/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@netflix/x-element": "2.0.0-rc.1"
+    "@netflix/x-element": "2.0.0-rc.2"
   }
 }

--- a/vendor/x-parser.js
+++ b/vendor/x-parser.js
@@ -368,14 +368,14 @@ class Unforgiving {
   // Note that syntax highlighters expect the text after the “html” tag to be
   //  real HTML. Another reason to reject JS-y unicode is that it won’t be
   //  interpreted correctly by tooling that expects _html_.
-  // The only escapes we expect to see are for the “\” and “`” characters, which
-  //  you _must_ use if you need those literal characters.
+  // The only escapes we expect to see are for the “$”, “\”, and “`” characters,
+  //  which you _must_ use if you need those literal characters.
   // The simplest way to check this is to ensure that back slashes always come
   //  in pairs of two or a single back slash preceding a back tick.
   // Examples:
   //  - ok: html`&#8230;`, html`&#x2026;`, html`&mldr;`, html`&hellip;`, html`\\n`
   //  - not ok: html`\nhi\nthere`, html`\x8230`, html`\u2026`, html`\s\t\o\p\ \i\t\.`
-  static __rawJsEscape = /.*(?<!\\)(?:\\{2})*\\(?![\\`])/ys;
+  static __rawJsEscape = /.*(?<!\\)(?:\\{2})*\\(?![$\\`])/ys;
 
   //////////////////////////////////////////////////////////////////////////////
   // Character References //////////////////////////////////////////////////////


### PR DESCRIPTION
We need to allow templates like:

```js
html`${interpolatedText} and \${literal text}`
```