### PR TITLE
Bump “x-element” dependency to restrict “svg”.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial `XElement/no-invalid-html` eslint rule.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@netflix/x-element": "2.0.0-rc.3"
+        "@netflix/x-element": "2.0.0-rc.4"
       },
       "devDependencies": {
         "@netflix/eslint-config": "3.0.0",
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@netflix/x-element": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.3.tgz",
-      "integrity": "sha512-gmzYELeYhRyEm3Pb+IY7JYxvFykMLg2wla1Wex0sdM6WBMWZ2lGQIWJ0Iyj/PM8MGkB7g+aXmvNxDRJLBf47vQ==",
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.4.tgz",
+      "integrity": "sha512-3ZKSFvao9gxfUZ4lr/hEZaeUHsC9wrNICv7dEs9uq7hvB5FPnZjEY1IClONY/YboYk+ZNhb/BMf8sv7HbzKWdQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.11.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "/no-invalid-html.js"
   ],
   "dependencies": {
-    "@netflix/x-element": "2.0.0-rc.3"
+    "@netflix/x-element": "2.0.0-rc.4"
   },
   "devDependencies": {
     "@netflix/eslint-config": "3.0.0",

--- a/test.js
+++ b/test.js
@@ -160,6 +160,10 @@ test('no-invalid-html', (/*context*/) => {
         errors: [{ message: /^\[#153\]/ }],
       },
       {
+        code: 'html`<svg></svg>`',
+        errors: [{ message: /^\[#153\]/ }],
+      },
+      {
         code: 'html`<main>`',
         errors: [{ message: /^\[#154\]/ }],
       },


### PR DESCRIPTION
The upstream `x-element` dependency no longer supports `svg` tags out of the box — by bumping the version there, this linter will also report problems related to any / all `svg` usage within `html` tagged template function invocations.