### PR TITLE
Update package.json engines

### DIFF
--- a/.github/workflows/publish-to-jsr.yaml
+++ b/.github/workflows/publish-to-jsr.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '22.x'
+          node-version: '20.18'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       # Can we get this to use “deno publish”?

--- a/.github/workflows/publish-to-jsr.yaml
+++ b/.github/workflows/publish-to-jsr.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.18'
+          node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       # Can we get this to use “deno publish”?

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '22.x'
+          node-version: '20.18'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.18'
+          node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.18'
+          node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '22.x'
+          node-version: '20.18'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@netflix/x-element": "2.0.0-rc.4"
+        "@netflix/x-element": "2.0.0-rc.5"
       },
       "devDependencies": {
         "@netflix/eslint-config": "3.0.0",
         "eslint": "9.20.0"
       },
       "engines": {
-        "node": "22.11.0",
-        "npm": "10.9.0"
+        "node": ">=20.18",
+        "npm": ">=10.8"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -207,13 +207,12 @@
       }
     },
     "node_modules/@netflix/x-element": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.4.tgz",
-      "integrity": "sha512-3ZKSFvao9gxfUZ4lr/hEZaeUHsC9wrNICv7dEs9uq7hvB5FPnZjEY1IClONY/YboYk+ZNhb/BMf8sv7HbzKWdQ==",
-      "license": "Apache-2.0",
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.5.tgz",
+      "integrity": "sha512-RTEy99lCNn6+R0JxB4cCz8iGobL9jN+gd1DgviOnVXeMVn8ZDPT/8Ik+o4EOtpzguLJL+I1SmxN/bFLwdufyNg==",
       "engines": {
-        "node": "22.11.0",
-        "npm": "10.9.0"
+        "node": ">=20.18",
+        "npm": ">=10.8"
       }
     },
     "node_modules/@types/estree": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@netflix/x-element": "2.0.0-rc.5"
+        "@netflix/x-element": "2.0.0-rc.6"
       },
       "devDependencies": {
         "@netflix/eslint-config": "3.0.0",
@@ -207,12 +207,13 @@
       }
     },
     "node_modules/@netflix/x-element": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.5.tgz",
-      "integrity": "sha512-RTEy99lCNn6+R0JxB4cCz8iGobL9jN+gd1DgviOnVXeMVn8ZDPT/8Ik+o4EOtpzguLJL+I1SmxN/bFLwdufyNg==",
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.6.tgz",
+      "integrity": "sha512-jzxjwJweRPCB0ilfafLyNi95Y6emRtl9aM9yVpevi+w9dmVUmOz/z98+U6sK4ymbHDaO7I7XKAt3fA/toj1i2w==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=20.18",
-        "npm": ">=10.8"
+        "node": ">=22.14",
+        "npm": ">=10.9"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
     "/no-invalid-html.js"
   ],
   "dependencies": {
-    "@netflix/x-element": "2.0.0-rc.5"
+    "@netflix/x-element": "2.0.0-rc.6"
   },
   "devDependencies": {
     "@netflix/eslint-config": "3.0.0",
     "eslint": "9.20.0"
   },
   "engines": {
-    "node": ">=20.18",
-    "npm": ">=10.8"
+    "node": ">=22.14",
+    "npm": ">=10.9"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
     "/no-invalid-html.js"
   ],
   "dependencies": {
-    "@netflix/x-element": "2.0.0-rc.4"
+    "@netflix/x-element": "2.0.0-rc.5"
   },
   "devDependencies": {
     "@netflix/eslint-config": "3.0.0",
     "eslint": "9.20.0"
   },
   "engines": {
-    "node": "22.11.0",
-    "npm": "10.9.0"
+    "node": ">=20.18",
+    "npm": ">=10.8"
   },
   "contributors": [
     {


### PR DESCRIPTION
Relaxing the required engine versions per: https://nodejs.org/en/about/previous-releases

The plugin code requires `set` syntax support in NodeJS — I haven't found confirmation yet of which LTS version supports this feature. Version 20 has LTS through April 2026 — using `nvm` I installed `20.18.3` which is the current LTS patch version today:

```
nvm install v20.18.3
...
Now using node v20.18.3 (npm v10.8.2)
```

This tells me which `npm` version to target as well
