### PR TITLE
Reject all usage of “style” tags.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@netflix/x-element": "2.0.0-rc.6"
+        "@netflix/x-element": "2.0.0-rc.7"
       },
       "devDependencies": {
         "@netflix/eslint-config": "3.0.0",
         "eslint": "9.20.0"
       },
       "engines": {
-        "node": ">=20.18",
-        "npm": ">=10.8"
+        "node": ">=22.14",
+        "npm": ">=10.9"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@netflix/x-element": {
-      "version": "2.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.6.tgz",
-      "integrity": "sha512-jzxjwJweRPCB0ilfafLyNi95Y6emRtl9aM9yVpevi+w9dmVUmOz/z98+U6sK4ymbHDaO7I7XKAt3fA/toj1i2w==",
+      "version": "2.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@netflix/x-element/-/x-element-2.0.0-rc.7.tgz",
+      "integrity": "sha512-eyqhfEAPXVLU7Z7XZ19GmJVo7lGeb2Y9H9sZUa782oXcuDI59sD+2qqinGAkmktTi1LS9ikuA9MKzR6YAL0byA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.14",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "/no-invalid-html.js"
   ],
   "dependencies": {
-    "@netflix/x-element": "2.0.0-rc.6"
+    "@netflix/x-element": "2.0.0-rc.7"
   },
   "devDependencies": {
     "@netflix/eslint-config": "3.0.0",
@@ -37,6 +37,10 @@
     {
       "name": "Andrew Seier",
       "email": "aseier@netflix.com"
+    },
+    {
+      "name": "Casey Klebba",
+      "email": "cklebba@netflix.com"
     }
   ]
 }

--- a/test.js
+++ b/test.js
@@ -160,7 +160,19 @@ test('no-invalid-html', (/*context*/) => {
         errors: [{ message: /^\[#153\]/ }],
       },
       {
+        code: 'html`<style></style>`',
+        errors: [{ message: /^\[#153\]/ }],
+      },
+      {
+        code: 'html`<canvas></canvas>`',
+        errors: [{ message: /^\[#153\]/ }],
+      },
+      {
         code: 'html`<svg></svg>`',
+        errors: [{ message: /^\[#153\]/ }],
+      },
+      {
+        code: 'html`<math></math>`',
         errors: [{ message: /^\[#153\]/ }],
       },
       {


### PR DESCRIPTION
This change set just bumps the underlying `x-element` version which will now throw for any usage of `<style>` within `html` tagged template function invocations.